### PR TITLE
Make python3 compatable

### DIFF
--- a/sqlalchemy_elasticquery/__init__.py
+++ b/sqlalchemy_elasticquery/__init__.py
@@ -1,1 +1,1 @@
-from elastic_query import elastic_query
+from .elastic_query import elastic_query

--- a/sqlalchemy_elasticquery/elastic_query.py
+++ b/sqlalchemy_elasticquery/elastic_query.py
@@ -114,7 +114,7 @@ class ElasticQuery(object):
         """ Parse the operators and traduce: ES to SQLAlchemy operators """
         if type(field_value) is dict:
             # TODO: check operators and emit error
-            operator = field_value.keys()[0]
+            operator = list(field_value)[0]
             if self.verify_operator(operator) is False:
                 return "Error: operador no exite", operator
             value = field_value[operator]


### PR DESCRIPTION
Change **init**.py to use explicit relative import
In python3 dick.keys() now returns a dict_key object, fixed this with list(dict) gives list of keys
