### PR TITLE
relative import in __init__

### DIFF
--- a/sqlalchemy_elasticquery/__init__.py
+++ b/sqlalchemy_elasticquery/__init__.py
@@ -1,1 +1,1 @@
-from elastic_query import elastic_query
+from .elastic_query import elastic_query


### PR DESCRIPTION
Use relative import so the package doesn't crash for python3