### PR TITLE
Extended filtering by allowing multiple conditions on single field

### DIFF
--- a/sqlalchemy_elasticquery/elastic_query.py
+++ b/sqlalchemy_elasticquery/elastic_query.py
@@ -128,7 +128,9 @@ class ElasticQuery(object):
         elif type(field_value) is unicode:
             operator = u'equals'
             value = field_value
-        return [(field, operator, value)]
+            output.append((field, operator, value))
+
+        return output
 
     @staticmethod
     def verify_operator(operator):


### PR DESCRIPTION
Added possibility filter single field by multiple operators, for example:

{
   "filter":{
      "event_at":{
         "gte":"2018-07-11 12:00:00",
         "lte":"2018-07-11 14:00:00"
      }
   }
}